### PR TITLE
Add support for streamed HTTP request

### DIFF
--- a/OnionBrowser/ConnectionKit/CKHTTPConnection.h
+++ b/OnionBrowser/ConnectionKit/CKHTTPConnection.h
@@ -31,6 +31,7 @@
     
     CFHTTPMessageRef       _HTTPRequest;
     NSInputStream                   *_HTTPStream;
+    NSInputStream                   *_HTTPBodyStream;
     BOOL                            _haveReceivedResponse;
     CKHTTPAuthenticationChallenge   *_authenticationChallenge;
     NSInteger                       _authenticationAttempts;

--- a/OnionBrowser/ConnectionKit/CKHTTPConnection.m
+++ b/OnionBrowser/ConnectionKit/CKHTTPConnection.m
@@ -86,7 +86,8 @@
         
         // Kick off the connection
         _HTTPRequest = [request makeHTTPMessage];
-        
+        _HTTPBodyStream = [request HTTPBodyStream];
+
         [self start];
     }
     
@@ -123,7 +124,12 @@
 {
     NSAssert(!_HTTPStream, @"Connection already started");
     
-    _HTTPStream = (__bridge_transfer NSInputStream *)CFReadStreamCreateForHTTPRequest(NULL, [self HTTPRequest]);
+    if (_HTTPBodyStream)
+        _HTTPStream = (__bridge NSInputStream *)(CFReadStreamCreateForStreamedHTTPRequest(NULL, [self HTTPRequest], (__bridge CFReadStreamRef)_HTTPBodyStream));
+    else
+        _HTTPStream = (__bridge_transfer NSInputStream *)CFReadStreamCreateForHTTPRequest(NULL, [self HTTPRequest]);
+    
+    CFReadStreamSetProperty((__bridge CFReadStreamRef)(_HTTPStream), kCFStreamPropertyHTTPAttemptPersistentConnection, kCFBooleanTrue);
 
     AppDelegate *appDelegate = [[UIApplication sharedApplication] delegate];
 


### PR DESCRIPTION
Add support for streamed HTTP request, it's required when upload massive data to server, for example: post large images from album or camera

This patch should fix failure when upload an image to Twitter.
