### PR TITLE
Use standard 3-clause BSD license for Endless code

### DIFF
--- a/Endless/Resources/credits.html.in
+++ b/Endless/Resources/credits.html.in
@@ -32,7 +32,7 @@
 <p>Onion Browser is developed by Mike Tigas (<a href="https://mike.tig.as/">https://mike.tig.as/</a> | <a href="http://tigas3l7uusztiqu.onion/">tigas3l7uusztiqu.onion</a>) with assistance from the Guardian Project (<a href="https://guardianproject.info/">guardianproject.info</a>). Benjamin Erhart (<a href="https://die.netzarchitekten.com/">Die Netzarchitekten</a>) and Carrie Winfrey (<a href="http://okthankscreative.com/">okthankscreative.com</a>) contributed additional design and development effort for Onion Browser 2.0.</p>
 <p>Work on Onion Browser is supported by individual donors and organizations
 committed to furthering free speech and digital privacy. Please consider donating to support continued development of Onion Browser and other Tor iOS initiatives:<br><a href="https://mike.tig.as/onionbrowser/#support-project">https://mike.tig.as/onionbrowser/#support-project</a></p>
-<p>Onion Browser 2.0 and newer is based on the open-source Endless Browser; special thanks to Joshua Stein for creating Endless and for granting permission to use it in Onion Browser.</p>
+<p>Onion Browser 2.0 and newer is based on the open-source Endless Browser; special thanks to joshua stein for creating Endless and for granting permission to use it in Onion Browser.</p>
 
 <p>Use of the app is under the terms of the <a href="https://www.apple.com/legal/internet-services/itunes/appstore/dev/stdeula/">standard iOS App Store End User License Agreement</a> and the below licenses and disclaimers. Onion Browser is provided as-is and use of the app is at your own risk. Remember: sensitive data does not always belong on a mobile device.</p>
 
@@ -158,16 +158,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 <strong>Endless</strong> - https://github.com/jcs/endless
 Copyright &copy; 2014-2019 joshua stein &lt;jcs@jcs.org&gt;
 
-Redistribution and use in source form, with or without modification, and use in binary form, is permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
-
-Redistribution in binary form, with or without modification, is not permitted except by the following:
-
-- Superblock, LLC
-- Psiphon, Inc.
-- Tigas Ventures, LLC ("Mike Tigas")
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>

--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,3 @@
-(NOTE: This is not a BSD/ISC/MIT license.  You are permitted to use this
-source code, with or without modification, in source or binary form, on
-your devices however you see fit.  You are not permitted to redistribute
-binaries of this source code, with or without modification.  In other
-words, you cannot put this application or any application derived from
-it, on the Apple App Store, Cydia, or any other binary-only distribution
-channel.)
-
-
 Onion Browser (version 2.0 and newer) is based on code from Endless and is
 distributed, with permission, under the terms of the Endless License. The
 Endless License is reproduced in full below the Onion Browser License.
@@ -24,10 +15,6 @@ are met:
 2. The name of the author may not be used to endorse or promote products
    derived from this software without specific prior written permission.
 
-Redistribution of this project in binary form, with or without modification,
-is NOT permitted without the explicit written permission of the Endless
-copyright holder.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -42,23 +29,19 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 Endless
-Copyright (c) 2014-2017 joshua stein <jcs@jcs.org>
+Copyright (c) 2014-2019 joshua stein <jcs@jcs.org>
 
-Redistribution and use in source form, with or without modification,
-and use in binary form, is permitted provided that the following conditions
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
 are met:
 
 1. Redistributions of source code must retain the above copyright
    notice, this list of conditions and the following disclaimer.
-2. The name of the author may not be used to endorse or promote products
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
    derived from this software without specific prior written permission.
-
-Redistribution in binary form, with or without modification, is NOT
-permitted except by the following:
-
-- Superblock, LLC
-- Psiphon, Inc.
-- Tigas Ventures, LLC ("Mike Tigas")
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
@@ -70,6 +53,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-For 3rd party software licenses, see Endless/Resources/credits.html

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ These people helped with translations. Thank you so much, folks!
 ## Contributors
 
 This project exists thanks to all the people who contribute. 
-<a href="graphs/contributors"><img src="https://opencollective.com/OnionBrowser/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/OnionBrowser/OnionBrowser/graphs/contributors"><img src="https://opencollective.com/OnionBrowser/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Onion Browser** is a free web browser for iPhone and iPad that encrypts and tunnels web traffic through the [Tor network][tor]. See the [official site][official] for more details and App Store links.
 
-Please see the [LICENSE][license] file for usage and redistribution terms. As of the 2.X (Endless-based) tree, redistribution of this software in binary form, with or without modification, is not permitted. (The previous [1.X tree][1.X] of Onion Browser was available under [a different license](https://github.com/OnionBrowser/OnionBrowser/blob/1.X/LICENSE).)
+Please see the [LICENSE][license] file for usage and redistribution terms.
 
 ---
 


### PR DESCRIPTION
I took Endless out of the App Store a while ago and I'm no longer maintaining it.  I'm permitting its code as used in Onion Browser to be licensed under the standard 3-clause BSD license which removes restrictions on binary redistribution.