### PR TITLE
Compare pointer to nil instead of to boolean

### DIFF
--- a/Endless/CookieJar.m
+++ b/Endless/CookieJar.m
@@ -389,7 +389,7 @@
 			}
 		}
 		
-		if (blocker) {
+		if (blocker == nil) {
 #ifdef TRACE_COOKIES
 			NSLog(@"[Tab h%@] data for %@ in use on tab %@, not deleting", tabHashN, cookieDomain, blocker);
 #endif


### PR DESCRIPTION
`NSNumber * blocker` can be compared to `nil` instead of being converted to a `bool`.