### PR TITLE
Update New York Times onion address

### DIFF
--- a/OnionBrowser/Bookmarks/Bookmark.swift
+++ b/OnionBrowser/Bookmarks/Bookmark.swift
@@ -33,7 +33,7 @@ open class Bookmark: NSObject {
 		var defaults = [Bookmark]()
 
 		defaults.append(Bookmark(name: "DuckDuckGo", url: "https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/"))
-		defaults.append(Bookmark(name: "New York Times", url: "https://mobile.nytimes3xbfgragh.onion/"))
+		defaults.append(Bookmark(name: "New York Times", url: "https://www.nytimesn7cgmftshazwhfgzm37qxb44r64ytbb2dj3x62d2lljsciiyd.onion/"))
 		defaults.append(Bookmark(name: "BBC", url: "https://www.bbcnewsd73hkzno2ini43t4gblxvycyac5aw4gnv7t2rccijh7745uqd.onion/"))
 		defaults.append(Bookmark(name: "ProPublica", url: "https://p53lf57qovyuvwsc6xnrppyply3vtqm7l6pcobkmyqsiofyeznfu5uqd.onion/"))
 		defaults.append(Bookmark(name: "Freedom of the Press Foundation", url: "http://fpfjxcrmw437h6z2xl3w4czl55kvkmxpapg37bbopsafdu7q454byxid.onion/"))


### PR DESCRIPTION
Ref: https://open.nytimes.com/https-open-nytimes-com-the-new-york-times-as-a-tor-onion-service-e0d0b67b7482