### PR TITLE
Change tab preview(usign snapshot instead of small webview)

### DIFF
--- a/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
+++ b/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
@@ -87,10 +87,8 @@ UICollectionViewDropDelegate, TabCellDelegate {
 	// MARK: UICollectionViewDelegate
 
 	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-		if let cell = collectionView.cellForItem(at: indexPath) as? TabCell {
-			currentTab = tabs[indexPath.row]
-			hideOverview(completion: nil)
-		}
+		currentTab = tabs[indexPath.row]
+		hideOverview(completion: nil)
 	}
 
 	// MARK: UICollectionViewDelegateFlowLayout

--- a/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
+++ b/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
@@ -20,7 +20,7 @@ UICollectionViewDropDelegate, TabCellDelegate {
 
 	@objc func showOverview() {
 		unfocusSearchField()
-
+		
 		self.tabsCollection.reloadData()
 
 		view.backgroundColor = .darkGray
@@ -72,8 +72,8 @@ UICollectionViewDropDelegate, TabCellDelegate {
 				let tab = tabs[indexPath.row]
 
 				cell.title.text = tab.title
-
-				tab.add(to: cell.container)
+				
+				cell.preview.image = tab.snapshot
 				tab.isHidden = false
 				tab.isUserInteractionEnabled = false
 			}
@@ -84,12 +84,12 @@ UICollectionViewDropDelegate, TabCellDelegate {
 		return cell
 	}
 
-
+	
 	// MARK: UICollectionViewDelegate
 
 	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 		if let cell = collectionView.cellForItem(at: indexPath) as? TabCell {
-			currentTab = tabs.first { $0 == cell.container.subviews.first }
+			currentTab = tabs[indexPath.row]
 			hideOverview(completion: nil)
 		}
 	}
@@ -177,7 +177,7 @@ UICollectionViewDropDelegate, TabCellDelegate {
 	// MARK: Private Methods
 
 	private func hideOverview(completion: ((_ finished: Bool) -> Void)?) {
-
+		currentTab?.resetSnapshot()
 		// UIViews can only ever have one superview. Move back from tabsCollection to container now.
 		for tab in tabs {
 			tab.isHidden = tab != currentTab

--- a/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
+++ b/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
@@ -53,7 +53,15 @@ UICollectionViewDropDelegate, TabCellDelegate {
 		hideOverview(completion: nil)
 	}
 
+	private func cellSize() -> CGSize {
+		let size = UIScreen.main.bounds.size
 
+		// Could be 0 or less, so secure against becoming negative with minimum width of smallest iOS device.
+		let width = (min(max(320, size.width), max(320, size.height)) - 8 * 2 /* left and right inset */) / 2 - 8 /* spacing */
+
+		return CGSize(width: width, height: width / 4 * 3)
+	}
+	
 	// MARK: UICollectionViewDataSource
 
 	func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -72,8 +80,8 @@ UICollectionViewDropDelegate, TabCellDelegate {
 				let tab = tabs[indexPath.row]
 
 				cell.title.text = tab.title
-				
-				cell.preview.image = tab.snapshot
+								
+				cell.preview.image = tab.snapshot?.topCropped(newSize: cellSize())
 				tab.isHidden = false
 			}
 
@@ -95,13 +103,7 @@ UICollectionViewDropDelegate, TabCellDelegate {
 
 	func collectionView(_ collectionView: UICollectionView, layout
 		collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-
-		let size = UIScreen.main.bounds.size
-
-		// Could be 0 or less, so secure against becoming negative with minimum width of smallest iOS device.
-		let width = (min(max(320, size.width), max(320, size.height)) - 8 * 2 /* left and right inset */) / 2 - 8 /* spacing */
-
-		return CGSize(width: width, height: width / 4 * 3)
+		return cellSize()
 	}
 
 

--- a/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
+++ b/OnionBrowser/Browsing/BrowsingViewController+Tabs.swift
@@ -20,7 +20,7 @@ UICollectionViewDropDelegate, TabCellDelegate {
 
 	@objc func showOverview() {
 		unfocusSearchField()
-		
+
 		self.tabsCollection.reloadData()
 
 		view.backgroundColor = .darkGray
@@ -75,7 +75,6 @@ UICollectionViewDropDelegate, TabCellDelegate {
 				
 				cell.preview.image = tab.snapshot
 				tab.isHidden = false
-				tab.isUserInteractionEnabled = false
 			}
 
 			cell.delegate = self
@@ -181,7 +180,6 @@ UICollectionViewDropDelegate, TabCellDelegate {
 		// UIViews can only ever have one superview. Move back from tabsCollection to container now.
 		for tab in tabs {
 			tab.isHidden = tab != currentTab
-			tab.isUserInteractionEnabled = true
 			tab.add(to: container)
 		}
 

--- a/OnionBrowser/Browsing/BrowsingViewController.xib
+++ b/OnionBrowser/Browsing/BrowsingViewController.xib
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -72,7 +73,7 @@
                                     </connections>
                                 </textField>
                             </subviews>
-                            <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="mql-7P-9gx" secondAttribute="trailing" id="079-ZF-15f"/>
                                 <constraint firstItem="mql-7P-9gx" firstAttribute="top" secondItem="M16-AT-yxd" secondAttribute="top" id="0bk-oc-Awa"/>
@@ -100,13 +101,13 @@
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N7h-ch-TdU">
                             <rect key="frame" x="0.0" y="79" width="414" height="1"/>
-                            <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" systemColor="systemGrayColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="CQZ-JN-Xw2"/>
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="SP4-s8-0b8" firstAttribute="leading" secondItem="RJ2-NH-hB6" secondAttribute="leadingMargin" id="2Ir-X5-HdU"/>
                         <constraint firstAttribute="height" constant="80" id="4Et-fm-zpa"/>
@@ -122,15 +123,15 @@
                     </constraints>
                 </view>
                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Af6-aJ-isr">
-                    <rect key="frame" x="0.0" y="78" width="414" height="2"/>
+                    <rect key="frame" x="0.0" y="76" width="414" height="4"/>
                 </progressView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VpS-hG-MKQ">
                     <rect key="frame" x="0.0" y="80" width="414" height="733"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
                 <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Q4p-od-FKg">
                     <rect key="frame" x="0.0" y="44" width="414" height="769"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="scrollViewTexturedBackgroundColor"/>
+                    <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="8" minimumInteritemSpacing="8" id="UbB-FU-EXR">
                         <size key="itemSize" width="50" height="50"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -149,11 +150,11 @@
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MAl-48-5A7">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="1"/>
-                            <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <viewLayoutGuide key="safeArea" id="T9o-E4-JNE"/>
+                            <color key="backgroundColor" systemColor="systemGrayColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="YmO-xM-9Lg"/>
                             </constraints>
-                            <viewLayoutGuide key="safeArea" id="T9o-E4-JNE"/>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="jzs-tH-FB8">
                             <rect key="frame" x="0.0" y="1" width="414" height="48"/>
@@ -205,14 +206,14 @@
                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ncz-tm-LKE">
                             <rect key="frame" x="0.0" y="1" width="414" height="48"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kSI-5C-QWW">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kSI-5C-QWW">
                                     <rect key="frame" x="192" y="0.0" width="30" height="48"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                     <state key="normal" title="+">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K4r-Tu-xYl">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K4r-Tu-xYl">
                                     <rect key="frame" x="357" y="7.5" width="41" height="33"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <state key="normal" title="Done">
@@ -229,7 +230,7 @@
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="ncz-tm-LKE" firstAttribute="leading" secondItem="LVl-ag-DII" secondAttribute="leading" id="0rX-40-vW7"/>
                         <constraint firstItem="MAl-48-5A7" firstAttribute="top" secondItem="LVl-ag-DII" secondAttribute="top" id="2r6-Es-6Vs"/>
@@ -246,7 +247,8 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="VpS-hG-MKQ" firstAttribute="top" secondItem="RJ2-NH-hB6" secondAttribute="bottom" id="2Jq-yE-1aC"/>
                 <constraint firstItem="VpS-hG-MKQ" firstAttribute="top" secondItem="Af6-aJ-isr" secondAttribute="bottom" id="7Vn-8h-pPZ"/>
@@ -266,7 +268,6 @@
                 <constraint firstAttribute="trailing" secondItem="Af6-aJ-isr" secondAttribute="trailing" id="suE-MZ-BKY"/>
                 <constraint firstItem="RJ2-NH-hB6" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="uYS-If-aan"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-57.971014492753625" y="152.67857142857142"/>
         </view>
         <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="ed4-6N-Nf3">
@@ -288,5 +289,17 @@
         <namedColor name="Accent">
             <color red="0.24699999392032623" green="0.16899999976158142" blue="0.31000000238418579" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="scrollViewTexturedBackgroundColor">
+            <color red="0.43529411764705878" green="0.44313725490196082" blue="0.47450980392156861" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/OnionBrowser/Browsing/Tab.swift
+++ b/OnionBrowser/Browsing/Tab.swift
@@ -179,10 +179,10 @@ class Tab: UIView {
 	private var _snapshot: UIImage? = nil
 
 	var snapshot: UIImage? {
-			if _snapshot == nil {
-				_snapshot = layer.makeSnapshot(scale: 1.0)
-			}
-			return _snapshot!
+		if _snapshot == nil {
+			_snapshot = layer.makeSnapshot(scale: 1.0)
+		}
+		return _snapshot
 	}
 	
 	

--- a/OnionBrowser/Browsing/Tab.swift
+++ b/OnionBrowser/Browsing/Tab.swift
@@ -183,11 +183,8 @@ class Tab: UIView {
 				_snapshot = layer.makeSnapshot(scale: 1.0)
 			}
 			return _snapshot!
-		}
-	
-	func resetSnapshot() {
-		_snapshot = nil
 	}
+	
 	
 	init(restorationId: String?) {
 		super.init(frame: .zero)
@@ -337,8 +334,12 @@ class Tab: UIView {
 			DispatchQueue.main.sync(execute: block)
 		}
 	}
-
-
+	
+	func resetSnapshot() {
+		_snapshot = nil
+	}
+	
+	
 	// MARK: Private Methods
 
 	private func setup(_ restorationId: String? = nil) {

--- a/OnionBrowser/Browsing/Tab.swift
+++ b/OnionBrowser/Browsing/Tab.swift
@@ -176,7 +176,19 @@ class Tab: UIView {
 		return refresher
 	}()
 
+	private var _snapshot: UIImage? = nil
 
+	var snapshot: UIImage? {
+			if _snapshot == nil {
+				_snapshot = layer.makeSnapshot(scale: 1.0)
+			}
+			return _snapshot!
+		}
+	
+	func resetSnapshot() {
+		_snapshot = nil
+	}
+	
 	init(restorationId: String?) {
 		super.init(frame: .zero)
 
@@ -197,7 +209,6 @@ class Tab: UIView {
 		if url == URL.start {
 			Bookmark.updateStartPage()
 		}
-
 		needsRefresh = false
 		skipHistory = true
 		webView.reload()

--- a/OnionBrowser/Browsing/Tab.swift
+++ b/OnionBrowser/Browsing/Tab.swift
@@ -209,6 +209,7 @@ class Tab: UIView {
 		if url == URL.start {
 			Bookmark.updateStartPage()
 		}
+
 		needsRefresh = false
 		skipHistory = true
 		webView.reload()

--- a/OnionBrowser/Browsing/TabCell.swift
+++ b/OnionBrowser/Browsing/TabCell.swift
@@ -25,6 +25,7 @@ class TabCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     @IBOutlet weak var title: UILabel!
 
     @IBOutlet weak var container: UIView!
+	@IBOutlet weak var preview: UIImageView!
 
     weak var delegate: TabCellDelegate?
 

--- a/OnionBrowser/Browsing/TabCell.swift
+++ b/OnionBrowser/Browsing/TabCell.swift
@@ -25,7 +25,7 @@ class TabCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     @IBOutlet weak var title: UILabel!
 
     @IBOutlet weak var container: UIView!
-	@IBOutlet weak var preview: UIImageView!
+    @IBOutlet weak var preview: UIImageView!
 
     weak var delegate: TabCellDelegate?
 

--- a/OnionBrowser/Browsing/TabCell.xib
+++ b/OnionBrowser/Browsing/TabCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -52,13 +53,25 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdQ-GP-s1R">
                         <rect key="frame" x="0.0" y="24" width="325" height="247"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="B4a-JY-zhJ">
+                                <rect key="frame" x="0.0" y="0.0" width="325" height="247"/>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <accessibility key="accessibilityConfiguration">
                             <accessibilityTraits key="traits" notEnabled="YES"/>
                         </accessibility>
+                        <constraints>
+                            <constraint firstItem="B4a-JY-zhJ" firstAttribute="top" secondItem="hdQ-GP-s1R" secondAttribute="top" id="5js-w0-gAc"/>
+                            <constraint firstItem="B4a-JY-zhJ" firstAttribute="leading" secondItem="hdQ-GP-s1R" secondAttribute="leading" id="8r7-3P-09u"/>
+                            <constraint firstAttribute="trailing" secondItem="B4a-JY-zhJ" secondAttribute="trailing" id="UrT-HZ-kOm"/>
+                            <constraint firstAttribute="bottom" secondItem="B4a-JY-zhJ" secondAttribute="bottom" id="X5I-wA-Ihh"/>
+                        </constraints>
                     </view>
                 </subviews>
             </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <gestureRecognizers/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="Eej-Rl-uVU" secondAttribute="trailing" id="Bdk-br-xBC"/>
@@ -69,10 +82,10 @@
                 <constraint firstItem="hdQ-GP-s1R" firstAttribute="top" secondItem="Eej-Rl-uVU" secondAttribute="bottom" id="xM7-xV-4Ae"/>
                 <constraint firstAttribute="bottom" secondItem="hdQ-GP-s1R" secondAttribute="bottom" id="zlg-U3-Ckg"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <size key="customSize" width="325" height="271"/>
             <connections>
                 <outlet property="container" destination="hdQ-GP-s1R" id="QH2-bH-Lt6"/>
+                <outlet property="preview" destination="B4a-JY-zhJ" id="iXm-fd-qh2"/>
                 <outlet property="title" destination="rP8-hS-ldO" id="QNi-Oy-PiV"/>
             </connections>
             <point key="canvasLocation" x="141.30434782608697" y="179.79910714285714"/>
@@ -80,5 +93,8 @@
     </objects>
     <resources>
         <image name="close" width="35" height="35"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/OnionBrowser/Helpers/CALayer+Helpers.swift
+++ b/OnionBrowser/Helpers/CALayer+Helpers.swift
@@ -13,11 +13,14 @@ import Foundation
 extension CALayer {
 	func makeSnapshot(scale: CGFloat = UIScreen.main.scale) -> UIImage? {
 		UIGraphicsBeginImageContextWithOptions(frame.size, false, scale)
-		defer { UIGraphicsEndImageContext() }
-		guard let context = UIGraphicsGetCurrentContext() else { return nil }
+		defer {
+			UIGraphicsEndImageContext()
+		}
+		guard let context = UIGraphicsGetCurrentContext() else {
+			return nil
+		}
 		render(in: context)
 		let screenshot = UIGraphicsGetImageFromCurrentImageContext()
-		UIGraphicsEndImageContext()
 		return screenshot
 	}
 }

--- a/OnionBrowser/Helpers/CALayer+Helpers.swift
+++ b/OnionBrowser/Helpers/CALayer+Helpers.swift
@@ -1,0 +1,23 @@
+//
+//  CALayer+Helpers.swift
+//  OnionBrowser2
+//
+//  Created by alexey kosylo on 29/04/2022.
+//  Copyright © 2022 Tigas Ventures, LLC (Mike Tigas). All rights reserved.
+//
+//  This file is part of Onion Browser. See LICENSE file for redistribution terms.
+//
+
+import Foundation
+
+extension CALayer {
+	func makeSnapshot(scale: CGFloat = UIScreen.main.scale) -> UIImage? {
+		UIGraphicsBeginImageContextWithOptions(frame.size, false, scale)
+		defer { UIGraphicsEndImageContext() }
+		guard let context = UIGraphicsGetCurrentContext() else { return nil }
+		render(in: context)
+		let screenshot = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		return screenshot
+	}
+}

--- a/OnionBrowser/Helpers/UIImage+Helpers.swift
+++ b/OnionBrowser/Helpers/UIImage+Helpers.swift
@@ -36,4 +36,29 @@ extension UIImage {
 
 		return tintedImage ?? self
 	}
+	
+	func topCropped(newSize:CGSize) -> UIImage? {
+		var ratio: CGFloat = 0
+		var delta: CGFloat = 0
+		var drawRect = CGRect()
+
+		if newSize.width > newSize.height {
+			ratio = newSize.width / size.width
+			delta = (ratio * size.height) - newSize.height
+			drawRect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height + delta)
+		} else {
+			ratio = newSize.height / size.height
+			delta = (ratio * size.width) - newSize.width
+			drawRect = CGRect(x: 0, y: 0, width: newSize.width + delta, height: newSize.height)
+		}
+		defer {
+			UIGraphicsEndImageContext()
+		}
+		
+		UIGraphicsBeginImageContextWithOptions(newSize, true, 0.0)
+		draw(in: drawRect)
+		let newImage = UIGraphicsGetImageFromCurrentImageContext()
+		
+		return newImage
+	}
 }

--- a/OnionBrowser2.xcodeproj/project.pbxproj
+++ b/OnionBrowser2.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		01F879481A41141800A63654 /* urlblocker_mock_rules.plist in Resources */ = {isa = PBXBuildFile; fileRef = 01F879461A41141800A63654 /* urlblocker_mock_rules.plist */; };
 		01F879491A41141800A63654 /* urlblocker_mock_targets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 01F879471A41141800A63654 /* urlblocker_mock_targets.plist */; };
 		112D9606ED61CB4ABFC252E9 /* Pods_OnionBrowser2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A668F273811C8050C2D8766 /* Pods_OnionBrowser2.framework */; };
+		54F7DBC8281C189700CBEFDB /* CALayer+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F7DBC7281C189700CBEFDB /* CALayer+Helpers.swift */; };
 		69CBCD471E934228009D5352 /* URLBlockerRuleController.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CBCD461E934228009D5352 /* URLBlockerRuleController.m */; };
 		69CBCD4D1E934249009D5352 /* RuleEditorRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CBCD4B1E934249009D5352 /* RuleEditorRow.m */; };
 		69CBCD521E9347B8009D5352 /* UIResponder+FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CBCD511E9347B8009D5352 /* UIResponder+FirstResponder.m */; };
@@ -231,6 +232,7 @@
 		01F879461A41141800A63654 /* urlblocker_mock_rules.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = urlblocker_mock_rules.plist; sourceTree = "<group>"; };
 		01F879471A41141800A63654 /* urlblocker_mock_targets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = urlblocker_mock_targets.plist; sourceTree = "<group>"; };
 		0A668F273811C8050C2D8766 /* Pods_OnionBrowser2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OnionBrowser2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		54F7DBC7281C189700CBEFDB /* CALayer+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Helpers.swift"; sourceTree = "<group>"; };
 		5E09F423B26A07BFF3E2DACD /* Pods-OnionBrowser2.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OnionBrowser2.debug.xcconfig"; path = "Target Support Files/Pods-OnionBrowser2/Pods-OnionBrowser2.debug.xcconfig"; sourceTree = "<group>"; };
 		693145FD1D3EEAE400D08A6A /* Tor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tor.framework; path = Carthage/Build/iOS/Tor.framework; sourceTree = "<group>"; };
 		69CBCD451E934228009D5352 /* URLBlockerRuleController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLBlockerRuleController.h; sourceTree = "<group>"; };
@@ -876,6 +878,7 @@
 				A0BF523823AFC3580096624A /* UIViewController+Helpers.swift */,
 				A0BF524023AFC3580096624A /* URL+Helpers.swift */,
 				A013DED92434E69A0087D12B /* UIImage+Helpers.swift */,
+				54F7DBC7281C189700CBEFDB /* CALayer+Helpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1261,6 +1264,7 @@
 				A0BF527C23AFC3580096624A /* UIView+Helpers.swift in Sources */,
 				A0BF524823AFC3580096624A /* Bridge.m in Sources */,
 				A053137822F1EC19006655EC /* DownloadHelper.m in Sources */,
+				54F7DBC8281C189700CBEFDB /* CALayer+Helpers.swift in Sources */,
 				A0BF525F23AFC3580096624A /* BrowsingViewController+UITextFieldDelegate.swift in Sources */,
 				69CBCD521E9347B8009D5352 /* UIResponder+FirstResponder.m in Sources */,
 				A0BF528123AFC3580096624A /* TabSecurity.swift in Sources */,


### PR DESCRIPTION
i started using Onion Browser and saw that tabs previews are not displayed quite like the tabs themselves look like in full screen.
And not exactly as displayed in safari for IOS
Instead of using a small webview, I suggest using snapshots of the open page.

Opened first page:
![Simulator Screen Shot - iPhone 11 - 2022-04-29 at 14 51 26](https://user-images.githubusercontent.com/1705170/166696725-8091f5e7-a598-405f-b685-39e35f9d6099.png)

Opened tab before my changes:
![IMG_0085](https://user-images.githubusercontent.com/1705170/166696583-26d6c21c-1f19-4615-8eb8-178fec6c7837.PNG)
Opened tab after my changes:
![Simulator Screen Shot - iPhone 11 - 2022-05-05 at 18 42 14](https://user-images.githubusercontent.com/1705170/166960955-c102386c-d02f-4c96-bc5b-ba04f140d72a.png)

