### PR TITLE
Change deprecated function SecTrustGetCertificateAtIndex to SecTrustCopyCertificateChain

### DIFF
--- a/Endless/SSLCertificate.m
+++ b/Endless/SSLCertificate.m
@@ -33,7 +33,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 
 - (id)initWithSecTrustRef:(SecTrustRef)secTrustRef
 {
-	SecCertificateRef cert = SecTrustGetCertificateAtIndex(secTrustRef, 0);
+	SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(SecTrustCopyCertificateChain(secTrustRef), 0);
 	NSData *data = (__bridge_transfer NSData *)SecCertificateCopyData(cert);
 	
 	if (!(self = [self initWithData:data]))


### PR DESCRIPTION
SecTrustGetCertificateAtIndex has deprecated since iOS 15.0. Apple recommends using SecTrustCopyCertificateChain instead. Since the return value of SecTrustCopyCertificateChain is CFArray, we need to get the object in the first index with CFArrayGetValueAtIndex. I haven't tested this code yet since the test does not run on my Xcode. This pull request should not be accepted until someone tests SSLCertificate_Tests.