### PR TITLE
Modernize Objective-C syntax (with some updates)

### DIFF
--- a/Endless/NSString+IPAddress.m
+++ b/Endless/NSString+IPAddress.m
@@ -15,7 +15,7 @@
 {
 	struct in_addr dst;
 	int success;
-	const char *utf8 = [self UTF8String];
+	const char *utf8 = self.UTF8String;
 
 	success = inet_pton(AF_INET, utf8, &dst);
 	if (success != 1) {

--- a/Endless/RuleEditorController.m
+++ b/Endless/RuleEditorController.m
@@ -11,7 +11,7 @@
 
 UISearchController *searchController;
 
-- (id)initWithStyle:(UITableViewStyle)style
+- (instancetype)initWithStyle:(UITableViewStyle)style
 {
 	self = [super initWithStyle:style];
 	
@@ -55,11 +55,11 @@ UISearchController *searchController;
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
 	if (section == 0)
-		return [self.inUseRuleRows count];
+		return (self.inUseRuleRows).count;
 	else if ([self isFiltering])
-		return [self.searchResult count];
+		return (self.searchResult).count;
 	else
-		return [self.sortedRuleRows count];
+		return (self.sortedRuleRows).count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -73,7 +73,7 @@ UISearchController *searchController;
 	
 	RuleEditorRow *row = [self ruleForTableView:tableView atIndexPath:indexPath];
 
-	cell.textLabel.text = [row textLabel];
+	cell.textLabel.text = row.textLabel;
 	
 	NSString *disabled = [self ruleDisabledReason:row];
 	if (disabled == nil) {
@@ -86,14 +86,14 @@ UISearchController *searchController;
 			cell.detailTextLabel.textColor = UIColor.darkGrayColor;
 		}
 
-		cell.detailTextLabel.text = [row detailTextLabel];
+		cell.detailTextLabel.text = row.detailTextLabel;
 	}
 	else {
 		cell.textLabel.textColor = UIColor.systemRedColor;
-		if ([row detailTextLabel] == nil || [[row detailTextLabel] isEqualToString:@""])
+		if (row.detailTextLabel == nil || [row.detailTextLabel isEqualToString:@""])
 			cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Disabled: %@", nil), disabled];
 		else
-			cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"%1$@ (Disabled: %2$@)", nil), [row detailTextLabel], disabled];
+			cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"%1$@ (Disabled: %2$@)", nil), row.detailTextLabel, disabled];
 		cell.detailTextLabel.textColor = UIColor.systemRedColor;
 	}
 	
@@ -152,16 +152,16 @@ UISearchController *searchController;
 	[self.searchResult removeAllObjects];
 
 	for (RuleEditorRow *row in self.sortedRuleRows) {
-		if ([row textLabel] != nil) {
-			NSRange range = [[row textLabel] rangeOfString:search options:NSCaseInsensitiveSearch];
+		if (row.textLabel != nil) {
+			NSRange range = [row.textLabel rangeOfString:search options:NSCaseInsensitiveSearch];
 
 			if (range.length > 0) {
 				[self.searchResult addObject:row];
 				continue;
 			}
 		}
-		if ([row detailTextLabel] != nil) {
-			NSRange range = [[row detailTextLabel] rangeOfString:search options:NSCaseInsensitiveSearch];
+		if (row.detailTextLabel != nil) {
+			NSRange range = [row.detailTextLabel rangeOfString:search options:NSCaseInsensitiveSearch];
 
 			if (range.length > 0) {
 				[self.searchResult addObject:row];
@@ -198,15 +198,15 @@ UISearchController *searchController;
 {
 	NSMutableArray *group;
 
-	if ([indexPath section] == 0)
-		group = [self inUseRuleRows];
+	if (indexPath.section == 0)
+		group = self.inUseRuleRows;
 	else if ([self isFiltering])
-		group = [self searchResult];
+		group = self.searchResult;
 	else
-		group = [self sortedRuleRows];
+		group = self.sortedRuleRows;
 
-	if (group && [group count] > [indexPath row])
-		return [group objectAtIndex:indexPath.row];
+	if (group && group.count > indexPath.row)
+		return group[indexPath.row];
 	else
 		return nil;
 }

--- a/Endless/SSLCertificate.m
+++ b/Endless/SSLCertificate.m
@@ -19,7 +19,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 #define CERT_CACHE_KEY_CERT @"key"
 #define CERT_CACHE_KEY_TIME @"time"
 
-- (id)init {
+- (instancetype)init {
 	if (!(self = [super init]))
 		return nil;
 	
@@ -31,7 +31,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	return self;
 }
 
-- (id)initWithSecTrustRef:(SecTrustRef)secTrustRef
+- (instancetype)initWithSecTrustRef:(SecTrustRef)secTrustRef
 {
 	SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(SecTrustCopyCertificateChain(secTrustRef), 0);
 	NSData *data = (__bridge_transfer NSData *)SecCertificateCopyData(cert);
@@ -53,7 +53,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	return self;
 }
 
-- (id)initWithData:(NSData *)data
+- (instancetype)initWithData:(NSData *)data
 {
 	/* x509 cert structure:
 
@@ -82,7 +82,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	if (!(self = [self init]))
 		return nil;
 	
-	NSData *certHash = [data dataWithSHA1Hash];
+	NSData *certHash = data.dataWithSHA1Hash;
 	
 	NSMutableDictionary *ocdef = certCache[certHash];
 	if (ocdef) {
@@ -136,7 +136,7 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	NSObject *tt = [self safeFetchFromArray:cert atIndex:1 withType:nil];
 	NSMutableArray *tserial = [[NSMutableArray alloc] initWithCapacity:16];
 	if (tt != nil && [tt isKindOfClass:[NSNumber class]]) {
-		long ttn = [(NSNumber *)tt longValue];
+		long ttn = ((NSNumber *)tt).longValue;
 		while (ttn > 0) {
 			[tserial addObject:[NSString stringWithFormat:@"%02lx", (ttn & 0xff)]];
 			ttn >>= 8;
@@ -144,8 +144,8 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 		tserial = [[NSMutableArray alloc] initWithArray:tserial.reverseObjectEnumerator.allObjects];
 	}
 	else if (tt != nil && [tt isKindOfClass:[NSData class]]) {
-		u_char *tbytes = (u_char *)[(NSData *)tt bytes];
-		for (int i = 0; i < [(NSData *)tt length]; i++)
+		u_char *tbytes = (u_char *)((NSData *)tt).bytes;
+		for (int i = 0; i < ((NSData *)tt).length; i++)
 			[tserial addObject:[NSString stringWithFormat:@"%02x", tbytes[i]]];
 	}
 	_serialNumber = [tserial componentsJoinedByString:@":"];
@@ -185,12 +185,12 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	if (issuerData == nil)
 		return nil;
 	NSMutableDictionary *tissuer = [@{} mutableCopy];
-	for (int i = 0; i < [issuerData count]; i++) {
+	for (int i = 0; i < issuerData.count; i++) {
 		NSArray *pairA = [self safeFetchFromArray:issuerData atIndex:i withType:[NSArray class]];
 		if (pairA == nil)
 			continue;
 		
-		for (int j = 0; j < [pairA count]; j++) {
+		for (int j = 0; j < pairA.count; j++) {
 			NSArray *oidPair = [self safeFetchFromArray:pairA atIndex:j withType:[NSArray class]];
 			if (oidPair == nil)
 				return nil;
@@ -221,12 +221,12 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	NSArray *tsubjectData = [self safeFetchFromArray:cert atIndex:5 withType:[NSArray class]];
 	if (tsubjectData == nil)
 		return nil;
-	for (int i = 0; i < [tsubjectData count]; i++) {
+	for (int i = 0; i < tsubjectData.count; i++) {
 		NSArray *pairA = [self safeFetchFromArray:tsubjectData atIndex:i withType:[NSArray class]];
 		if (pairA == nil)
 			continue;
 		
-		for (int j = 0; j < [pairA count]; j++) {
+		for (int j = 0; j < pairA.count; j++) {
 			NSArray *oidPair = [self safeFetchFromArray:pairA atIndex:j withType:[NSArray class]];
 			if (oidPair == nil)
 				return nil;
@@ -379,13 +379,13 @@ static NSMutableDictionary <NSData *, NSMutableDictionary *> *certCache = nil;
 	case kTLSProtocol13:
 		return @"TLS 1.3";
 	default:
-		return [NSString stringWithFormat:@"Unknown (%d)", [self negotiatedProtocol]];
+		return [NSString stringWithFormat:@"Unknown (%d)", self.negotiatedProtocol];
 	}
 }
 
 - (NSString *)negotiatedCipherString
 {
-	switch ([self negotiatedCipher]) {
+	switch (self.negotiatedCipher) {
 	case SSL_NULL_WITH_NULL_NULL:
 		return @"SSL_NULL_WITH_NULL_NULL";
 	case SSL_RSA_WITH_NULL_MD5:

--- a/Endless/URLBlockerRuleController.m
+++ b/Endless/URLBlockerRuleController.m
@@ -12,11 +12,11 @@
 
 @implementation URLBlockerRuleController
 
-- (id)initWithStyle:(UITableViewStyle)style
+- (instancetype)initWithStyle:(UITableViewStyle)style
 {
 	self = [super initWithStyle:style];
 	
-	self.sortedRuleRows = [[NSMutableArray alloc] initWithCapacity:[[URLBlocker targets] count]];
+	self.sortedRuleRows = [[NSMutableArray alloc] initWithCapacity:[URLBlocker targets].count];
 	self.inUseRuleRows = [[NSMutableArray alloc] init];
 	
 	NSMutableDictionary *inUse = [NSMutableDictionary new];
@@ -32,13 +32,13 @@
 		}
 	}
 	
-	for (NSString *k in [[[URLBlocker targets] allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]) {
+	for (NSString *k in [[URLBlocker targets].allKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]) {
 		RuleEditorRow *row = [[RuleEditorRow alloc] init];
 		row.key = k;
 		row.textLabel = k;
-		row.detailTextLabel = [[URLBlocker targets] objectForKey:k];
+		row.detailTextLabel = [URLBlocker targets][k];
 		
-		if (inUse && [inUse objectForKey:k])
+		if (inUse && inUse[k])
 			[self.inUseRuleRows addObject:row];
 		else
 			[self.sortedRuleRows addObject:row];
@@ -54,17 +54,17 @@
 
 - (NSString *)ruleDisabledReason:(RuleEditorRow *)row
 {
-	return [[URLBlocker disabledTargets] objectForKey:[row key]];
+	return [URLBlocker disabledTargets][row.key];
 }
 
 - (void)disableRuleForRow:(RuleEditorRow *)row withReason:(NSString *)reason
 {
-	[URLBlocker disableTargetByHost:[row key] withReason:reason];
+	[URLBlocker disableTargetByHost:row.key withReason:reason];
 }
 
 - (void)enableRuleForRow:(RuleEditorRow *)row
 {
-	[URLBlocker enableTargetByHost:[row key]];
+	[URLBlocker enableTargetByHost:row.key];
 }
 
 @end

--- a/OnionBrowser.xcodeproj/project.pbxproj
+++ b/OnionBrowser.xcodeproj/project.pbxproj
@@ -864,7 +864,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1120;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "Tigas Ventures, LLC (Mike Tigas)";
 				TargetAttributes = {
 					01801E911A32CA2A002B4718 = {

--- a/OnionBrowser.xcodeproj/xcshareddata/xcschemes/OBVersion.xcscheme
+++ b/OnionBrowser.xcodeproj/xcshareddata/xcschemes/OBVersion.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OnionBrowser.xcodeproj/xcshareddata/xcschemes/OnionBrowser.xcscheme
+++ b/OnionBrowser.xcodeproj/xcshareddata/xcschemes/OnionBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,24 +6,24 @@ PODS:
   - FavIcon (3.1.0)
   - ImageRow (4.1.0):
     - Eureka (~> 5.3.5)
-  - IPtProxy (3.2.1)
-  - IPtProxyUI (4.1.3):
+  - IPtProxy (3.3.0)
+  - IPtProxyUI (4.2.1):
     - Eureka (~> 5.3)
-    - IPtProxy (~> 3.2.1)
-    - IPtProxyUI/App (= 4.1.3)
-  - IPtProxyUI/App (4.1.3):
+    - IPtProxy (~> 3.3.0)
+    - IPtProxyUI/App (= 4.2.1)
+  - IPtProxyUI/App (4.2.1):
     - Eureka (~> 5.3)
-    - IPtProxy (~> 3.2.1)
-    - ProgressHUD (~> 13.8)
+    - IPtProxy (~> 3.3.0)
+    - ProgressHUD (~> 14.1)
   - MBProgressHUD (1.2.0)
-  - OCMock (3.9.1)
+  - OCMock (3.9.3)
   - OrbotKit (1.1.0)
-  - ProgressHUD (13.8.6)
+  - ProgressHUD (14.1.0)
   - SDCAlertView (10.0)
-  - Tor/Core (408.7.2)
-  - Tor/CTor (408.7.2):
+  - Tor/Core (408.10.1)
+  - Tor/CTor (408.10.1):
     - Tor/Core
-  - Tor/GeoIP (408.7.2):
+  - Tor/GeoIP (408.10.1):
     - Tor/CTor
   - TUSafariActivity (1.0.4)
 
@@ -69,16 +69,16 @@ SPEC CHECKSUMS:
   Eureka: 28ad9dec6286cd7cd601fdf8e8df39bb7356a8f4
   FavIcon: 21651b47d8f6b33517973859f85e2cb6f9fcfaee
   ImageRow: 880c0f052c5a89c80521b485c86ccf723a124e99
-  IPtProxy: 95d2d173b15f84a9d61c7482f8ec5dfdf5d94247
-  IPtProxyUI: bb766cc69e30dfdf55dcb9fcc4da173c496f4e0c
+  IPtProxy: 2136e276560ffd3a1d017683259f52552fc7c2e5
+  IPtProxyUI: 1814ff18e9ce2d94eabc84dd0233a17f8953e791
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
-  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
+  OCMock: 300b1b1b9155cb6378660b981c2557448830bdc6
   OrbotKit: 5e69508dee1943144fefa18a197fbf2030dfbe36
-  ProgressHUD: ee8924300accca88bfa39f6350f757c1c869a69c
+  ProgressHUD: c4a55f108815c46a6bf082407d2f806840b7a869
   SDCAlertView: 5fbc48cae6d7bf9781097e3f27883924ef3b922c
-  Tor: 7e7ab1fa8b5140b0b5038cff45b9c9472ad73951
+  Tor: 4aa4aee031f892efa43d1afb01c90565990c6312
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
 
 PODFILE CHECKSUM: 71622f8d5911ffaf96398a9cfc63ea81d797ad3a
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.14.3

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -65,6 +65,27 @@
 	<string>Needed, if you want to unlock the app with Face ID.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Needed to store the selected image to your photos.</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).view</string>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>
@@ -105,26 +126,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-	<key>NSUserActivityTypes</key>
-	<array>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).view</string>
-	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR includes
 - Updating Podfile
 - Updating Xcode to 15.1
 - Modernizing Objective-C syntax

Conversion to string catalog needs support from Transifex

For modernizing objc syntax, I used Xcode's convert featuer (Edit->Convert->To Modern Objective-C Syntax...)

Most changes are about replacing `id` with `instancetype` and using dot to access properties rather than square brackets.

For the reason that I changed to `instancetype`, please read [Apple developer docs](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html#//apple_ref/doc/uid/TP40014150-CH1-SW11).

I think dot is better than square brackets since it is similar to Swift syntax.